### PR TITLE
change MON distribution graphic, and MON token holders pie chart

### DIFF
--- a/articles/Moneta/DCHF_report.md
+++ b/articles/Moneta/DCHF_report.md
@@ -342,8 +342,9 @@ DefiFranc_mon: LockedMONteam
 
 MON initial distribution directed tokens to the following addresses:
 
-![photo_2023-04-14 13 01 57](https://user-images.githubusercontent.com/51072084/232144288-c9c550b0-1323-4ce4-ae2e-ec57bc43a808.jpeg)
+![mon_distribution](https://user-images.githubusercontent.com/4058461/232518729-ade22691-2c4c-46b4-b8c4-92d351e953ee.png)
 
+Here is a [dashboard](https://dune.com/paulapivat/llama-risk-assessment-defi-franc) to show onchain transactions to and from the [Protocol Owner multi-sig](https://etherscan.io/address/0x83737EAe72ba7597b36494D723fbF58cAfee8A69); see "MON Received and In Circulation". 
 
 The [Treasury multi-sig](https://etherscan.io/address/0x5592cb82f5b11a4e42b1275a973e6b712194e239) currently holds around 50% of all tokens. Of circulating supply, the majority is in the [MONStaking contract](https://etherscan.io/token/0x1EA48B9965bb5086F3b468E50ED93888a661fc17?a=0x8bc3702c35d33e5df7cb0f06cb72a0c34ae0c56f) (17m) and the [Uniswap pool](https://etherscan.io/token/0x1EA48B9965bb5086F3b468E50ED93888a661fc17?a=0x21f396dd37a26d7754c513fd916d07f66aa6b81e) (3m). Since all allocations were made before the DAO was formed and without community input, there may be questions regarding the airdrops. The Grizzly.Fi community received the most tokens (11.17m), and it is worth noting that members of the core team are also co-founders of Grizzly.Fi. This overlap in roles may be a cause for concern, as the majority of MON circulating supply is from airdrops and the team's realized MON allocation is obscured by a significant airdrop to their previous project.
 
@@ -461,7 +462,7 @@ A list of access controls for the system contracts has been compiled on this [Go
 
 Here’s an overview of major MON token holders:
 
-![MON_token_distribution](https://user-images.githubusercontent.com/51072084/231855112-c2bea070-c719-4d52-be1a-015fb157ab2e.png)
+![MON_token_distribution](https://user-images.githubusercontent.com/4058461/232521246-a083515d-7a35-4172-8716-665116091442.png)
 
 [Source query](https://dune.com/queries/2320797/3800099)
 


### PR DESCRIPTION
I made 3 minor edits:

1. changed MON distribution graphic
2. added a link to the dashboard providing onchain data for MON distribution
3. changed MON token holders pie chart

cc: @Straytjacquet 